### PR TITLE
fix: add fit-content for links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14677,7 +14677,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14822,7 +14821,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -28141,7 +28139,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -28249,7 +28246,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"

--- a/src/components/ProfilePopup/ProfilePopup.scss
+++ b/src/components/ProfilePopup/ProfilePopup.scss
@@ -40,6 +40,7 @@
   color: var(--color-text-base);
   text-decoration: none;
   margin: 0;
+  width: fit-content;
 }
 
 .profile-popup__email {
@@ -51,6 +52,7 @@
   color: var(--color-text-additional);
   margin-top: 8px;
   margin-bottom: 20px;
+  width: fit-content;
 }
 
 .profile-popup__link {
@@ -62,6 +64,7 @@
   color: var(--color-text-base);
   text-decoration: none;
   margin-bottom: 16px;
+  width: fit-content;
 }
 
 .profile-popup__button {

--- a/src/pages/LoginPage/LoginPage.scss
+++ b/src/pages/LoginPage/LoginPage.scss
@@ -11,4 +11,5 @@
 .login__link {
   color: var(--color-accent-base);
   text-decoration: none;
+  width: fit-content;
 }


### PR DESCRIPTION
Исправила баги от тестировщиков. Ссылки были по ширине контейнера, хотя текст был маленький, и при клике на пустую область, срабатывал переход по ссылке.